### PR TITLE
feat-add-new-pages

### DIFF
--- a/app/certifications/page.tsx
+++ b/app/certifications/page.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { ArrowLeft } from "lucide-react";
 import Link from "next/link";
 import { BentoGridItem } from "@/components/ui";

--- a/app/certifications/page.tsx
+++ b/app/certifications/page.tsx
@@ -1,7 +1,36 @@
 import React from "react";
+import { ArrowLeft } from "lucide-react";
+import Link from "next/link";
+import { BentoGridItem } from "@/components/ui";
+import { CertificationsListsPreview } from "@/data/certification-list-preview";
 
 function Certifications() {
-    return <div>Certifications</div>;
+    return (
+        <main className="py-10 w-11/12 max-w-5xl gap-2 flex flex-col md:grid md:grid-cols-2">
+            <Link
+                href={"/"}
+                className="flex items-center gap-2 text-neutral-500 hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-200 transition duration-200"
+            >
+                <ArrowLeft size={15} />
+                <h1 className="text-sm">Back</h1>
+            </Link>
+            <div className="col-span-2 flex flex-col gap-5">
+                <h1 className="text-2xl text-center font-bold">All Certifications</h1>
+                <div className="col-span-2 grid grid-cols-1 md:grid-cols-2 gap-2">
+                    {CertificationsListsPreview.map((c) => {
+                        return (
+                            <Link href={c.link} target="_blank" key={c.link}>
+                                <BentoGridItem
+                                    title={<h1 className="text-lg">{c.title}</h1>}
+                                    description={<h1 className="text-xs md:text-base">{c.description}</h1>}
+                                />
+                            </Link>
+                        );
+                    })}
+                </div>
+            </div>
+        </main>
+    );
 }
 
 export default Certifications;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,7 +4,6 @@ import { Analytics } from "@vercel/analytics/react";
 import { ThemeProvider } from "@/provider/theme-provider";
 import { type ReactNode } from "react";
 import Footer from "@/components/organisms/footer";
-import { Separator } from "@/components/ui";
 
 const font = Quicksand({
     weight: ["400", "500", "600", "700"],
@@ -44,7 +43,6 @@ export default function RootLayout({ children }: { children: ReactNode }) {
             >
                 <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
                     {children}
-                    <Separator className="w-11/12 max-w-5xl" />
                     <Footer />
                 </ThemeProvider>
                 <Analytics />

--- a/app/techstack/page.tsx
+++ b/app/techstack/page.tsx
@@ -1,7 +1,72 @@
-import React from "react";
-
+import { FRONTEND, BACKEND, DEVELOPER_TOOLS, DEVOPS } from "@/data/techstack-array";
+import { BentoGridItem, Badge } from "@/components/ui";
+import { ArrowLeft } from "lucide-react";
+import Link from "next/link";
 function TechStack() {
-    return <div>TechStack</div>;
+    return (
+        <main className="py-10 w-11/12 max-w-5xl gap-2 flex flex-col md:grid md:grid-cols-2">
+            <Link
+                href={"/"}
+                className="flex items-center gap-2 text-neutral-500 hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-200 transition duration-200"
+            >
+                <ArrowLeft size={15} />
+                <h1 className="text-sm">Back</h1>
+            </Link>
+            <div className="col-Badge-2 flex flex-col gap-5">
+                <h1 className="text-2xl text-center font-bold">TechStack</h1>
+                <div className="col-Badge-2 grid grid-cols-1 md:grid-cols-2 gap-2">
+                    <BentoGridItem
+                        title={<h1 className="text-lg">Frontend</h1>}
+                        description={
+                            <div className="flex flex-wrap gap-2">
+                                {FRONTEND.map((item) => (
+                                    <Badge key={item} variant={"outline"}>
+                                        {item}
+                                    </Badge>
+                                ))}
+                            </div>
+                        }
+                    />
+                    <BentoGridItem
+                        title={<h1 className="text-lg">Backend</h1>}
+                        description={
+                            <div className="flex flex-wrap gap-2">
+                                {BACKEND.map((item) => (
+                                    <Badge key={item} variant={"outline"}>
+                                        {item}
+                                    </Badge>
+                                ))}
+                            </div>
+                        }
+                    />
+                    <BentoGridItem
+                        title={<h1 className="text-lg">DevOps & Cloud</h1>}
+                        description={
+                            <div className="flex flex-wrap gap-2">
+                                {DEVOPS.map((item) => (
+                                    <Badge key={item} variant={"outline"}>
+                                        {item}
+                                    </Badge>
+                                ))}
+                            </div>
+                        }
+                    />
+                    <BentoGridItem
+                        title={<h1 className="text-lg">Developer Tools</h1>}
+                        description={
+                            <div className="flex flex-wrap gap-2">
+                                {DEVELOPER_TOOLS.map((item) => (
+                                    <Badge key={item} variant={"outline"}>
+                                        {item}
+                                    </Badge>
+                                ))}
+                            </div>
+                        }
+                    />
+                </div>
+            </div>
+        </main>
+    );
 }
 
 export default TechStack;

--- a/components/organisms/footer.tsx
+++ b/components/organisms/footer.tsx
@@ -1,12 +1,20 @@
 import React from "react";
 import { ThemeToggler } from "../theme-toggler";
+import { Separator } from "@/components/ui";
 
 const Footer = () => {
     return (
-        <footer className="pt-3 flex items-center justify-between w-full max-w-5xl">
-            <p className="text-xs ml-3">© {new Date().getFullYear()} Froilan Aquino. All rights reserved.</p>
-            <ThemeToggler />
-        </footer>
+        <>
+            <footer className="pt-3 flex flex-col items-center justify-between w-full max-w-5xl">
+                <Separator className="w-11/12 max-w-5xl" />
+                <div className="flex flex-row items-center justify-between w-11/12 max-w-5xl py-5">
+                    <p className="text-xs md:text-sm ml-3">
+                        © {new Date().getFullYear()} Froilan Aquino. All rights reserved.
+                    </p>
+                    <ThemeToggler />
+                </div>
+            </footer>
+        </>
     );
 };
 

--- a/components/organisms/tech-stack-card.tsx
+++ b/components/organisms/tech-stack-card.tsx
@@ -1,49 +1,9 @@
 import { BentoGridItem, Badge } from "@/components/ui";
+import { FRONTEND, BACKEND, DEVELOPER_TOOLS, DEVOPS } from "@/data/techstack-array";
 import { cn } from "@/lib/utils";
 import { ArrowRightCircle, FlaskConical } from "lucide-react";
 import Link from "next/link";
 
-const FRONTEND = [
-    "HTML",
-    "CSS",
-    "JavaScript",
-    "TypeScript",
-    "React",
-    "Next.js",
-    "Tailwind CSS",
-    "Svelte",
-    "Prettier",
-    "ESLint",
-    "Styled Components",
-    "Webpack",
-];
-const BACKEND = ["Node.js", "Python", "Flask", "Django", "REST API", "MySQL", "PostgreSQL", "MongoDB", "Redis", "JWT"];
-const DEVOPS = [
-    "Docker",
-    "Kubernetes",
-    "AWS",
-    "Google Cloud Platform",
-    "Firebase",
-    "Vercel",
-    "GitHub Actions",
-    "CI/CD",
-];
-const DEVELOPER_TOOLS = [
-    "Git",
-    "GitHub",
-    "Postman",
-    "Figma",
-    "Visual Studio Code",
-    "Trello",
-    "Jira",
-    "PyCharm",
-    "IntelliJ IDEA",
-    "Android Studio",
-    "Sublimetext",
-    "Notion",
-    "Discord",
-    "Teams",
-];
 const TechStackCard = ({ className }: { className?: string }) => {
     return (
         <BentoGridItem
@@ -54,8 +14,7 @@ const TechStackCard = ({ className }: { className?: string }) => {
                     <h1 className="text-lg">Tech Stack</h1>
                     <Link
                         className="text-xs md:text-base text-neutral-500 hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-200 transition duration-200 flex items-center gap-2"
-                        href={"/tech-stack"}
-                        target="_blank"
+                        href={"/techstack"}
                     >
                         View All
                         <ArrowRightCircle size={15} />

--- a/data/techstack-array.ts
+++ b/data/techstack-array.ts
@@ -1,0 +1,58 @@
+const FRONTEND = [
+    "HTML",
+    "CSS",
+    "JavaScript",
+    "TypeScript",
+    "React",
+    "Next.js",
+    "Tailwind CSS",
+    "Svelte",
+    "Prettier",
+    "ESLint",
+    "Styled Components",
+    "Webpack",
+];
+const BACKEND = [
+    "Node.js",
+    "Python",
+    "Flask",
+    "Django",
+    "REST API",
+    "MySQL",
+    "PostgreSQL",
+    "MongoDB",
+    "Redis",
+    "JWT",
+    "Render",
+    "Railway",
+    "Supabase",
+    "Prisma",
+];
+const DEVOPS = [
+    "Docker",
+    "Kubernetes",
+    "AWS",
+    "Google Cloud Platform",
+    "Firebase",
+    "Vercel",
+    "GitHub Actions",
+    "CI/CD",
+];
+const DEVELOPER_TOOLS = [
+    "Git",
+    "GitHub",
+    "Postman",
+    "Figma",
+    "Visual Studio Code",
+    "Trello",
+    "Jira",
+    "PyCharm",
+    "IntelliJ IDEA",
+    "Android Studio",
+    "Sublimetext",
+    "Notion",
+    "Discord",
+    "Teams",
+];
+
+export { FRONTEND, BACKEND, DEVOPS, DEVELOPER_TOOLS };


### PR DESCRIPTION
This pull request introduces significant updates to the `Certifications` and `TechStack` pages, improves component modularity, and enhances the footer layout. The changes focus on restructuring the codebase for better maintainability and adding new features to improve user experience.

### Page Enhancements:

* [`app/certifications/page.tsx`](diffhunk://#diff-a5d29c89ebe7a2c7be6b6dc7e192540b2f77483a8e0faf9d47099dc3a3e970daL1-R32): Replaced the placeholder content with a fully functional `Certifications` page. Added a grid layout displaying certification previews using `BentoGridItem` components and a back navigation link.
* [`app/techstack/page.tsx`](diffhunk://#diff-d5889fe381d08aea2a361b875cb4718efdfef5a58330d9ae9ca897488a85a3b6L1-R69): Updated the `TechStack` page to include categorized tech stack items (Frontend, Backend, DevOps, Developer Tools) displayed in a grid layout with badges. Added a back navigation link.

### Codebase Modularization:

* [`data/techstack-array.ts`](diffhunk://#diff-34b91490f3c116bd71b7772d27309260c103df09a9679c60fcae9fb343bae794R1-R58): Extracted tech stack data arrays (e.g., `FRONTEND`, `BACKEND`) into a separate file for reusability across components.
* [`components/organisms/tech-stack-card.tsx`](diffhunk://#diff-9d98a0cc7ee13fbffe113f79c8a4a183e62a7d81dc0d2fce8a147880add32e31R2-L46): Updated the `TechStackCard` component to use the newly modularized data arrays and fixed the link to the `TechStack` page (`/techstack`). [[1]](diffhunk://#diff-9d98a0cc7ee13fbffe113f79c8a4a183e62a7d81dc0d2fce8a147880add32e31R2-L46) [[2]](diffhunk://#diff-9d98a0cc7ee13fbffe113f79c8a4a183e62a7d81dc0d2fce8a147880add32e31L57-R17)

### Footer Improvements:

* [`components/organisms/footer.tsx`](diffhunk://#diff-ccdf27f37f07d63cbd1ea64d012f5e974fcf85854f826cf797904d3f074a3232R3-R17): Enhanced the footer layout by adding a `Separator` component and improving the styling for better visual separation and responsiveness.

### Minor Cleanup:

* [`app/layout.tsx`](diffhunk://#diff-eca96d2c09f31517696a26e1d0be4070e1fbab02831481bed006e275741d030bL7): Removed the unused `Separator` component from the root layout to streamline the structure. [[1]](diffhunk://#diff-eca96d2c09f31517696a26e1d0be4070e1fbab02831481bed006e275741d030bL7) [[2]](diffhunk://#diff-eca96d2c09f31517696a26e1d0be4070e1fbab02831481bed006e275741d030bL47)